### PR TITLE
Use a request ID string instead of an amount to construct URL

### DIFF
--- a/src/PayWithFlexbase.ts
+++ b/src/PayWithFlexbase.ts
@@ -45,12 +45,12 @@ export class PayWithFlexbase extends HTMLElement {
         value ? this.setAttribute('apikey', value) : this.removeAttribute('apikey');
     }
 
-    get amount(): number | null {
-        return Number(this.getAttribute('amount'));
+    get request(): string | null {
+        return this.getAttribute('request');
     }
 
-    set amount(value) {
-        value ? this.setAttribute('amount', value.toString()) : this.removeAttribute('amount');
+    set request(value) {
+        value ? this.setAttribute('request', value) : this.removeAttribute('request');
     }
 
     get callback() {
@@ -84,13 +84,13 @@ export class PayWithFlexbase extends HTMLElement {
 
     protected buildUrl(): string {
         const apikey = this.apikey || '';
-        const amount = this.amount || 0;
+        const request = this.request || '';
         const callback = this.callback || '';
         const session = this.session || '';
 
         const q = this.buildQuery({
             apikey,
-            amount,
+            request,
             callback,
             session,
         });

--- a/src/PayWithFlexbaseProps.ts
+++ b/src/PayWithFlexbaseProps.ts
@@ -1,6 +1,6 @@
 export interface PayWithFlexbaseProps {
     apikey: string;
-    amount: number;
+    request: string;
     callback: string;
     session: string;
     flexbaseDomain?: string;

--- a/tests/PayWithFlexbase.test.tsx
+++ b/tests/PayWithFlexbase.test.tsx
@@ -14,7 +14,7 @@ test("PayWithFlexbase null attributes", () => {
     expect(rendered).not.toBeNull();
 
     expect(rendered!.getAttribute('apikey')).toBeNull();
-    expect(rendered!.getAttribute('amount')).toBeNull();
+    expect(rendered!.getAttribute('request')).toBeNull();
     expect(rendered!.getAttribute('callback')).toBeNull();
     expect(rendered!.getAttribute('session')).toBeNull();
     expect(rendered!.getAttribute('flexbaseDomain')).toBeNull();
@@ -26,13 +26,13 @@ test("PayWithFlexbase attributes", () => {
 
     const flexbaseDomain = "http://localhost"
     const apikey = "testApiKey";
-    const amount = 1.2;
+    const request = '123-423235-23232323';
     const session = "testSession";
     const callback = "/callback";
 
     const testEl = () => {
         return (
-            <pay-with-flexbase flexbaseDomain={flexbaseDomain} apikey={apikey} amount={amount} session={session} callback={callback} />
+            <pay-with-flexbase flexbaseDomain={flexbaseDomain} apikey={apikey} request={request} session={session} callback={callback} />
         )
     };
 
@@ -46,7 +46,7 @@ test("PayWithFlexbase attributes", () => {
     const rendered = el as PayWithFlexbase;
 
     expect(rendered.apikey).toBe(apikey);
-    expect(rendered.request).toBe(amount);
+    expect(rendered.request).toBe(request);
     expect(rendered.callback).toBe(callback);
     expect(rendered.session).toBe(session);
     expect(rendered.flexbaseDomain).toBe(flexbaseDomain);
@@ -58,13 +58,13 @@ test("PayWithFlexbase clear attributes", () => {
 
     const flexbaseDomain = "http://localhost"
     const apikey = "testApiKey";
-    const amount = 1.2;
+    const request = '123-423235-23232323';
     const session = "testSession";
     const callback = "/callback";
 
     const testEl = () => {
         return (
-            <pay-with-flexbase flexbaseDomain={flexbaseDomain} apikey={apikey} amount={amount} session={session} callback={callback} />
+            <pay-with-flexbase flexbaseDomain={flexbaseDomain} apikey={apikey} request={request} session={session} callback={callback} />
         )
     };
 
@@ -84,7 +84,7 @@ test("PayWithFlexbase clear attributes", () => {
     rendered.flexbaseDomain = null;
 
     expect(rendered.hasAttribute('apikey')).toBe(false);
-    expect(rendered.hasAttribute('amount')).toBe(false);
+    expect(rendered.hasAttribute('request')).toBe(false);
     expect(rendered.hasAttribute('callback')).toBe(false);
     expect(rendered.hasAttribute('session')).toBe(false);
     expect(rendered.hasAttribute('flexbaseDomain')).toBe(false);

--- a/tests/PayWithFlexbase.test.tsx
+++ b/tests/PayWithFlexbase.test.tsx
@@ -46,7 +46,7 @@ test("PayWithFlexbase attributes", () => {
     const rendered = el as PayWithFlexbase;
 
     expect(rendered.apikey).toBe(apikey);
-    expect(rendered.amount).toBe(amount);
+    expect(rendered.request).toBe(amount);
     expect(rendered.callback).toBe(callback);
     expect(rendered.session).toBe(session);
     expect(rendered.flexbaseDomain).toBe(flexbaseDomain);
@@ -78,7 +78,7 @@ test("PayWithFlexbase clear attributes", () => {
     const rendered = el as PayWithFlexbase;
 
     rendered.apikey = null;
-    rendered.amount = null;
+    rendered.request = null;
     rendered.callback = null;
     rendered.session = null;
     rendered.flexbaseDomain = null;


### PR DESCRIPTION
Eventually we can expand this to create the BNPL request, but for now it will probably run afoul of CORS